### PR TITLE
Add zero suppression filter

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -43,7 +43,7 @@ impl Node {
     pub fn cost(&self) -> u64 {
         match self {
             Self::And(left, right) | Self::Or(left, right) => left.cost() + right.cost(),
-            Self::Not(node) => node.cost(),
+            Self::Not(node) => node.cost() + 1,
             Self::Value(node) => node.cost(),
         }
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -47,4 +47,203 @@ impl Node {
             Self::Value(node) => node.cost(),
         }
     }
+
+    #[inline]
+    pub fn optimize(self) -> Self {
+        self.zero_suppression_filter(false)
+    }
+
+    pub fn zero_suppression_filter(self, negate: bool) -> Self {
+        match (self, negate) {
+            (Self::And(left, right), true) => Self::Or(
+                Box::new(left.zero_suppression_filter(true)),
+                Box::new(right.zero_suppression_filter(true)),
+            ),
+            (Self::Or(left, right), true) => Self::And(
+                Box::new(left.zero_suppression_filter(true)),
+                Box::new(right.zero_suppression_filter(true)),
+            ),
+            (Self::Not(value), true) => value.zero_suppression_filter(false),
+            (Self::Not(value), false) => value.zero_suppression_filter(true),
+            (Self::Value(predicate), true) => Self::Value(!predicate),
+            (Self::And(left, right), false) => {
+                Self::And(Box::new(left.optimize()), Box::new(right.optimize()))
+            }
+            (Self::Or(left, right), false) => {
+                Self::Or(Box::new(left.optimize()), Box::new(right.optimize()))
+            }
+            (value @ Self::Value(_), _) => value,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::{
+        events::{AttributeDefinition, AttributeTable},
+        predicates::PredicateKind,
+        test_utils::ast::{and, not, or, value},
+    };
+
+    #[test]
+    fn can_optimize_a_negated_or_expression() {
+        let attributes = define_attributes();
+        let a_predicate = Predicate::new(&attributes, "private", PredicateKind::Variable).unwrap();
+        let expression = not!(or!(
+            value!(a_predicate.clone()),
+            value!(!a_predicate.clone())
+        ));
+        assert_eq!(
+            and!(value!(!a_predicate.clone()), value!(a_predicate)),
+            expression.optimize()
+        );
+    }
+
+    #[test]
+    fn can_optimize_a_negated_and_expression() {
+        let attributes = define_attributes();
+        let a_predicate =
+            Predicate::new(&attributes, "private", PredicateKind::NegatedVariable).unwrap();
+        let expression = not!(and!(
+            value!(a_predicate.clone()),
+            value!(!a_predicate.clone())
+        ));
+
+        assert_eq!(
+            or!(value!(!a_predicate.clone()), value!(a_predicate)),
+            expression.optimize()
+        );
+    }
+
+    #[test]
+    fn can_optimize_a_negated_expression() {
+        let attributes = define_attributes();
+        let a_predicate = Predicate::new(&attributes, "private", PredicateKind::Variable).unwrap();
+        let expression = not!(value!(a_predicate.clone()));
+
+        assert_eq!(value!(!a_predicate), expression.optimize());
+    }
+
+    #[test]
+    fn can_optimize_a_negated_negated_expression() {
+        let attributes = define_attributes();
+        let a_predicate = Predicate::new(&attributes, "private", PredicateKind::Variable).unwrap();
+        let expression = not!(not!(value!(a_predicate.clone())));
+
+        assert_eq!(value!(a_predicate), expression.optimize());
+    }
+
+    #[test]
+    fn can_recursively_apply_the_optimizations() {
+        let attributes = define_attributes();
+        let a_predicate = Predicate::new(&attributes, "private", PredicateKind::Variable).unwrap();
+        let expression = not!(and!(
+            not!(or!(
+                value!(a_predicate.clone()),
+                value!(a_predicate.clone())
+            )),
+            and!(
+                or!(value!(a_predicate.clone()), value!(a_predicate.clone())),
+                or!(value!(a_predicate.clone()), value!(a_predicate.clone()))
+            )
+        ));
+
+        assert_eq!(
+            or!(
+                or!(value!(a_predicate.clone()), value!(a_predicate.clone())),
+                or!(
+                    and!(value!(!a_predicate.clone()), value!(!a_predicate.clone())),
+                    and!(value!(!a_predicate.clone()), value!(!a_predicate.clone()))
+                )
+            ),
+            expression.optimize()
+        );
+    }
+
+    #[test]
+    fn leave_unnegated_value_as_is() {
+        let attributes = define_attributes();
+        let a_predicate = Predicate::new(&attributes, "private", PredicateKind::Variable).unwrap();
+
+        assert_eq!(value!(a_predicate.clone()), value!(a_predicate).optimize());
+    }
+
+    #[test]
+    fn leave_unnegated_and_as_is() {
+        let attributes = define_attributes();
+        let a_predicate = Predicate::new(&attributes, "private", PredicateKind::Variable).unwrap();
+        let expression = and!(value!(a_predicate.clone()), value!(a_predicate));
+
+        assert_eq!(expression.clone(), expression.optimize());
+    }
+
+    #[test]
+    fn leave_unnegated_or_as_is() {
+        let attributes = define_attributes();
+        let a_predicate = Predicate::new(&attributes, "private", PredicateKind::Variable).unwrap();
+        let expression = or!(value!(a_predicate.clone()), value!(a_predicate));
+
+        assert_eq!(expression.clone(), expression.optimize());
+    }
+
+    #[test]
+    fn can_optimize_a_negated_and_expression_not_at_the_top_level() {
+        let attributes = define_attributes();
+        let a_predicate = Predicate::new(&attributes, "private", PredicateKind::Variable).unwrap();
+        let expression = and!(
+            not!(and!(
+                value!(a_predicate.clone()),
+                value!(a_predicate.clone())
+            )),
+            value!(a_predicate.clone())
+        );
+
+        assert_eq!(
+            and!(
+                or!(value!(!a_predicate.clone()), value!(!a_predicate.clone())),
+                value!(a_predicate)
+            ),
+            expression.optimize()
+        );
+    }
+
+    #[test]
+    fn can_optimize_a_negated_or_expression_not_at_the_top_level() {
+        let attributes = define_attributes();
+        let a_predicate = Predicate::new(&attributes, "private", PredicateKind::Variable).unwrap();
+        let expression = or!(
+            not!(or!(
+                value!(a_predicate.clone()),
+                value!(a_predicate.clone())
+            )),
+            value!(a_predicate.clone())
+        );
+
+        assert_eq!(
+            or!(
+                and!(value!(!a_predicate.clone()), value!(!a_predicate.clone())),
+                value!(a_predicate)
+            ),
+            expression.optimize()
+        );
+    }
+
+    fn define_attributes() -> AttributeTable {
+        let definitions = vec![
+            AttributeDefinition::string_list("deals"),
+            AttributeDefinition::string("deal"),
+            AttributeDefinition::integer("price"),
+            AttributeDefinition::integer("exchange_id"),
+            AttributeDefinition::boolean("private"),
+            AttributeDefinition::string_list("deal_ids"),
+            AttributeDefinition::integer_list("ids"),
+            AttributeDefinition::integer_list("segment_ids"),
+            AttributeDefinition::string("continent"),
+            AttributeDefinition::string("country"),
+            AttributeDefinition::string("city"),
+        ];
+        AttributeTable::new(&definitions).unwrap()
+    }
 }

--- a/src/atree.rs
+++ b/src/atree.rs
@@ -97,6 +97,7 @@ impl<T: Eq + Hash + Clone> ATree<T> {
     pub fn insert<'a>(&'a mut self, user_id: &T, abe: &'a str) -> Result<(), ATreeError<'a>> {
         let ast = parser::parse(abe, &self.attributes, &mut self.strings)
             .map_err(ATreeError::ParseError)?;
+        let ast = ast.optimize();
         self.insert_root(user_id, ast);
         Ok(())
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -176,7 +176,7 @@ impl<'atree> EventBuilder<'atree> {
 
 /// An event that can be used by the [`crate::atree::ATree`] structure to match arbitrary boolean
 /// expressions
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Event(Vec<AttributeValue>);
 
 impl Index<AttributeId> for Event {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -170,6 +170,13 @@ NullExpression: ast::Node = {
             left,
             predicates::PredicateKind::Null(predicates::NullOperator::IsEmpty)
         ).map(ast::Node::Value).map_err(|error| ParseError::User { error: ParserError::Event(error) })
+    },
+    <left:"identifier"> "is_not_empty" =>? {
+        predicates::Predicate::new(
+            attributes,
+            left,
+            predicates::PredicateKind::Null(predicates::NullOperator::IsNotEmpty)
+        ).map(ast::Node::Value).map_err(|error| ParseError::User { error: ParserError::Event(error) })
     }
 }
 
@@ -263,6 +270,7 @@ extern {
         "is_null" => Token::IsNull,
         "is_not_null" => Token::IsNotNull,
         "is_empty" => Token::IsEmpty,
+        "is_not_empty" => Token::IsNotEmpty,
         "and" => Token::And,
         "or" => Token::Or,
         "integer" => Token::IntegerLiteral(<i64>),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -49,6 +49,8 @@ pub enum Token<'source> {
     IsNotNull,
     #[token("is empty")]
     IsEmpty,
+    #[token("is not empty")]
+    IsNotEmpty,
     #[token("and")]
     #[token("&&")]
     And,
@@ -217,6 +219,12 @@ mod tests {
     fn can_lex_is_empty() {
         let actual = lex_tokens("is empty").unwrap();
         assert_eq!(vec![Token::IsEmpty], actual);
+    }
+
+    #[test]
+    fn can_lex_is_not_empty() {
+        let actual = lex_tokens("is not empty").unwrap();
+        assert_eq!(vec![Token::IsNotEmpty], actual);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! * Boolean operators: `and` (`&&`), `or` (`||`), `not` (`!`) and `variable` where `variable` is a defined attribute for the A-Tree;
 //! * Comparison: `<`, `<=`, `>`, `>=`. They work for `integer` and `float`;
 //! * Equality: `=` and `<>`. They work for `integer`, `float` and `string`;
-//! * Null: `is null`, `is not null` (for variables) and `is empty` (for lists);
+//! * Null: `is null`, `is not null` (for variables), `is empty` and `is not empty` (for lists);
 //! * Set: `in` and `not in`. They work for list of `integer` or for list of `string`;
 //! * List: `one of`, `none of` and `all of`. They work for list of `integer` and list of `string`.
 //!
@@ -87,6 +87,8 @@ mod lexer;
 mod parser;
 mod predicates;
 mod strings;
+#[cfg(test)]
+mod test_utils;
 
 pub use crate::{
     atree::{ATree, Report},

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -386,6 +386,26 @@ mod tests {
     }
 
     #[test]
+    fn can_parse_is_not_empty_expression() {
+        let mut strings = StringTable::new();
+        let attributes = define_attributes();
+
+        let parsed = parse("deals is not empty", &attributes, &mut strings);
+
+        assert_eq!(
+            Ok(Node::Value(
+                Predicate::new(
+                    &attributes,
+                    "deals",
+                    PredicateKind::Null(NullOperator::IsNotEmpty)
+                )
+                .unwrap()
+            )),
+            parsed
+        );
+    }
+
+    #[test]
     fn return_an_error_on_an_empty_list() {
         let mut strings = StringTable::new();
         let attributes = define_attributes();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,254 @@
+pub mod ast {
+    macro_rules! or {
+        ($left:expr, $right:expr) => {
+            Node::Or(Box::new($left), Box::new($right))
+        };
+    }
+
+    macro_rules! and {
+        ($left:expr, $right:expr) => {
+            Node::And(Box::new($left), Box::new($right))
+        };
+    }
+
+    macro_rules! not {
+        ($value:expr) => {
+            Node::Not(Box::new($value))
+        };
+    }
+
+    macro_rules! value {
+        ($value:expr) => {
+            Node::Value($value)
+        };
+    }
+
+    pub(crate) use and;
+    pub(crate) use not;
+    pub(crate) use or;
+    pub(crate) use value;
+}
+
+pub mod predicates {
+    macro_rules! variable {
+        ($attributes:expr, $name:expr) => {
+            predicate!($attributes, $name, PredicateKind::Variable)
+        };
+    }
+
+    macro_rules! negated_variable {
+        ($attributes:expr, $name:expr) => {
+            predicate!($attributes, $name, PredicateKind::NegatedVariable)
+        };
+    }
+
+    macro_rules! is_null {
+        ($attributes:expr, $name:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::Null(NullOperator::IsNull)
+            )
+        };
+    }
+
+    macro_rules! is_not_null {
+        ($attributes:expr, $name:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::Null(NullOperator::IsNotNull)
+            )
+        };
+    }
+
+    macro_rules! is_empty {
+        ($attributes:expr, $name:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::Null(NullOperator::IsEmpty)
+            )
+        };
+    }
+
+    macro_rules! is_not_empty {
+        ($attributes:expr, $name:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::Null(NullOperator::IsNotEmpty)
+            )
+        };
+    }
+
+    macro_rules! set_in {
+        ($attributes:expr, $name:expr, $value:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::Set(SetOperator::In, $value)
+            )
+        };
+    }
+
+    macro_rules! set_not_in {
+        ($attributes:expr, $name:expr, $value:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::Set(SetOperator::NotIn, $value)
+            )
+        };
+    }
+
+    macro_rules! equal {
+        ($attributes:expr, $name:expr, $value:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::Equality(EqualityOperator::Equal, $value)
+            )
+        };
+    }
+
+    macro_rules! not_equal {
+        ($attributes:expr, $name:expr, $value:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::Equality(EqualityOperator::NotEqual, $value)
+            )
+        };
+    }
+
+    macro_rules! less_than {
+        ($attributes:expr, $name:expr, $value:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::Comparison(ComparisonOperator::LessThan, $value)
+            )
+        };
+    }
+
+    macro_rules! less_than_equal {
+        ($attributes:expr, $name:expr, $value:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::Comparison(ComparisonOperator::LessThanEqual, $value)
+            )
+        };
+    }
+
+    macro_rules! greater_than {
+        ($attributes:expr, $name:expr, $value:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::Comparison(ComparisonOperator::GreaterThan, $value)
+            )
+        };
+    }
+
+    macro_rules! greater_than_equal {
+        ($attributes:expr, $name:expr, $value:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::Comparison(ComparisonOperator::GreaterThanEqual, $value)
+            )
+        };
+    }
+
+    macro_rules! all_of {
+        ($attributes:expr, $name:expr, $value:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::List(ListOperator::AllOf, $value)
+            )
+        };
+    }
+
+    macro_rules! one_of {
+        ($attributes:expr, $name:expr, $value:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::List(ListOperator::OneOf, $value)
+            )
+        };
+    }
+
+    macro_rules! none_of {
+        ($attributes:expr, $name:expr, $value:expr) => {
+            predicate!(
+                $attributes,
+                $name,
+                PredicateKind::List(ListOperator::NoneOf, $value)
+            )
+        };
+    }
+
+    macro_rules! comparison_float {
+        ($value:expr) => {
+            ComparisonValue::Float($value)
+        };
+    }
+
+    macro_rules! comparison_integer {
+        ($value:expr) => {
+            ComparisonValue::Integer($value)
+        };
+    }
+
+    macro_rules! string_list {
+        ($value:expr) => {
+            ListLiteral::StringList($value)
+        };
+    }
+
+    macro_rules! integer_list {
+        ($value:expr) => {
+            ListLiteral::IntegerList($value)
+        };
+    }
+
+    macro_rules! primitive_string {
+        ($value:expr) => {
+            PrimitiveLiteral::String($value)
+        };
+    }
+
+    macro_rules! predicate {
+        ($attributes:expr, $name:expr, $kind:expr) => {
+            Predicate::new($attributes, $name, $kind).unwrap()
+        };
+    }
+
+    pub(crate) use all_of;
+    pub(crate) use comparison_float;
+    pub(crate) use comparison_integer;
+    pub(crate) use equal;
+    pub(crate) use greater_than;
+    pub(crate) use greater_than_equal;
+    pub(crate) use integer_list;
+    pub(crate) use is_empty;
+    pub(crate) use is_not_empty;
+    pub(crate) use is_not_null;
+    pub(crate) use is_null;
+    pub(crate) use less_than;
+    pub(crate) use less_than_equal;
+    pub(crate) use negated_variable;
+    pub(crate) use none_of;
+    pub(crate) use not_equal;
+    pub(crate) use one_of;
+    pub(crate) use predicate;
+    pub(crate) use primitive_string;
+    pub(crate) use set_in;
+    pub(crate) use set_not_in;
+    pub(crate) use string_list;
+    pub(crate) use variable;
+}


### PR DESCRIPTION
That features propagate the `Node::Not` down to the predicates.

The rational behind that (quoting the paper):

> 5.2.1 Zero Suppression Filter. Because of the existence of the logical operators not, xor and xnor in ABEs, we must distinguish between the false and undefined evaluation results. The false evaluation result needs to be propagated, which can be very expensive. To remove the cost to propagate false results, we use the zero suppression filter optimization. Its basic idea is to remove the logical operators *not*, *xor* and *xnor* from an incoming ABE by applying the following laws: (1) $\lnot(E_1 \land E_2 ) = \lnot E_1 \lor \lnot E_2$ , (2) $\lnot (E_1 \lor E_2 ) = \lnot E_1 \land \lnot E_2$ , (3) $E_1 \oplus  E_2 = (E_1 \land \lnot E_2 ) \lor (\lnot E_1 \land E_2 )$, and (4) $E_1 \otimes E_2 = (E_1 \land E_2 ) \lor (\lnot E_1 \land \lnot E_2 )$
>
> In this formula, $\oplus$ and $\otimes$ are the symbols of _xor_ and _xnor_, respectively. In negation removal, by applying De Morgan’s laws, all negations are pushed downward level-by-level onto the predicates. Negations are then integrated into predicates (i.e., applied to the predicates) by using the inverse of the predicates’ relational operators: replacing greater than with less than or equal, equality with inequality, etc. Consider the expression $\lnot ((age > 60) \lor (weight > 100))$ as an example; it changes to $(age \leq 60) \land (weight \leq 100)$.
>
> With this optimization, when the evaluation result of any node is false, it is no longer propagated to any of its parents. Conversely,when computing the result of any node, if one of its operands is undefined, it is assumed to be false, and the result is computed accordingly. This optimization is promising because a _false_ result is often obtained for a substantial number of leaf and inner nodes in the A-Tree index while matching an event. Our experiments show that the event matching time can be reduced by a maximum of 85% with this optimization.